### PR TITLE
The default ship now spawns

### DIFF
--- a/voidcrew/_DEFINES/overmap.dm
+++ b/voidcrew/_DEFINES/overmap.dm
@@ -17,6 +17,3 @@
 #define OVERMAP_SHIP_ACTING "acting"
 #define OVERMAP_SHIP_DOCKING "docking"
 #define OVERMAP_SHIP_UNDOCKING "undocking"
-
-// minimum job slots for an initial ship
-#define OVERMAP_INITIAL_SHIP_JOB_SLOT_MINIMUM 5

--- a/voidcrew/modules/overmap/code/controllers/subsystem/overmap.dm
+++ b/voidcrew/modules/overmap/code/controllers/subsystem/overmap.dm
@@ -196,6 +196,9 @@ SUBSYSTEM_DEF(overmap)
 			var/datum/map_template/shuttle/voidcrew/random_template = pick_n_take(remaining_templates)
 			if(initial(random_template.abstract) == random_template)
 				continue
+			// the first ship will always be an NT or Syndicate one.
+			if(initial(random_template.faction_prefix) == NEUTRAL_SHIP)
+				continue
 			initial_ship_template = random_template
 
 	if(!initial_ship_template)

--- a/voidcrew/modules/overmap/code/controllers/subsystem/overmap.dm
+++ b/voidcrew/modules/overmap/code/controllers/subsystem/overmap.dm
@@ -194,8 +194,6 @@ SUBSYSTEM_DEF(overmap)
 		var/list/remaining_templates = subtypesof(/datum/map_template/shuttle/voidcrew)
 		while(!initial_ship_template && LAZYLEN(remaining_templates))
 			var/datum/map_template/shuttle/voidcrew/random_template = pick_n_take(remaining_templates)
-			if(initial(length(random_template.job_slots)) < OVERMAP_INITIAL_SHIP_JOB_SLOT_MINIMUM)
-				continue
 			if(initial(random_template.abstract) == random_template)
 				continue
 			initial_ship_template = random_template


### PR DESCRIPTION
## About The Pull Request

Removes the check of an empty job slot list because it didn't work. If this can be re-added in the future then I don't really have a problem with it, but I think it's better to limit it to NT/Syndicate ships.

## Why It's Good For The Game

We can work on roundstart spawning now that the first ship actually loads in.
Closes https://github.com/Willardstation/tg-voidcrew/issues/67
