### PR TITLE
Revert "planets no longer spawn on the outermost ring (the border)"

### DIFF
--- a/voidcrew/modules/overmap/code/controllers/subsystem/overmap.dm
+++ b/voidcrew/modules/overmap/code/controllers/subsystem/overmap.dm
@@ -151,7 +151,7 @@ SUBSYSTEM_DEF(overmap)
 
 /datum/controller/subsystem/overmap/proc/setup_planets()
 	var/list/orbits = list()
-	for (var/i in 2 to (LAZYLEN(radius_tiles) - 1))
+	for (var/i in 2 to LAZYLEN(radius_tiles))
 		orbits += "[i]"
 
 	for (var/_ in 1 to MAX_OVERMAP_PLANETS_TO_SPAWN)


### PR DESCRIPTION
Reverts Willardstation/tg-voidcrew#70

This didn't fix the problem, it just removed the numbers, they still spawn on the ring.