### PR TITLE
Nanite research-keeping is now on the Techweb

### DIFF
--- a/voidcrew/_DEFINES/nanite_defines.dm
+++ b/voidcrew/_DEFINES/nanite_defines.dm
@@ -7,8 +7,8 @@
 ///The chance at a Nanite program randomly failing when it cannot sync
 #define NANITE_FAILURE_CHANCE 8
 
-#define NANITE_SHOCK_IMMUNE 1
-#define NANITE_EMP_IMMUNE 2
+#define NANITE_SHOCK_IMMUNE (1<<0)
+#define NANITE_EMP_IMMUNE (1<<1)
 
 #define NANITE_CLOUD_TOGGLE 1
 #define NANITE_CLOUD_DISABLE 2

--- a/voidcrew/modules/nanites/code/extra_settings/rules.dm
+++ b/voidcrew/modules/nanites/code/extra_settings/rules.dm
@@ -1,6 +1,7 @@
 /datum/nanite_rule
 	var/name = "Generic Condition"
 	var/desc = "When triggered, the program is active"
+	///The affected nanite program
 	var/datum/nanite_program/program
 
 /datum/nanite_rule/New(datum/nanite_program/new_program)

--- a/voidcrew/modules/nanites/code/items/nanite_remote.dm
+++ b/voidcrew/modules/nanites/code/items/nanite_remote.dm
@@ -7,18 +7,26 @@
 /obj/item/nanite_remote
 	name = "nanite remote control"
 	desc = "A device that can remotely control active nanites through wireless signals."
-	w_class = WEIGHT_CLASS_SMALL
-	req_access = list(ACCESS_ROBOTICS)
+	req_access = list(ACCESS_RESEARCH)
 	icon = 'voidcrew/modules/nanites/icons/device.dmi'
 	icon_state = "nanite_remote"
 	item_flags = NOBLUDGEON
-	var/locked = FALSE //Can be locked, so it can be given to users with a set code and mode
+	w_class = WEIGHT_CLASS_SMALL
+
+	///Boolean on whether the remote is locked
+	var/locked = FALSE
+	///The mode of the remote, mode defines: REMOTE_MODE_OFF|REMOTE_MODE_SELF|REMOTE_MODE_TARGET|REMOTE_MODE_AOE|REMOTE_MODE_RELAY
 	var/mode = REMOTE_MODE_OFF
-	var/list/saved_settings = list()
+	///Keeping track of the last used ID
 	var/last_id = 0
+	///The code set to send on the remote.
 	var/code = 0
-	var/relay_code = 0
+	var/relay_code = 0 //tbh i have no clue what the shit this is
+	///The name of the currently active program.
 	var/current_program_name = "Program"
+
+	///List of all settings (also lists) saved on the remote.
+	var/list/saved_settings = list()
 
 /obj/item/nanite_remote/examine(mob/user)
 	. = ..()
@@ -76,9 +84,8 @@
 	SEND_SIGNAL(M, COMSIG_NANITE_SIGNAL, code, source)
 
 /obj/item/nanite_remote/proc/signal_relay(code, relay_code, source)
-	for(var/X in SSnanites.nanite_relays)
-		var/datum/nanite_program/relay/N = X
-		N.relay_signal(code, relay_code, source)
+	for(var/datum/nanite_program/relay/relays as anything in SSnanites.nanite_relays)
+		relays.relay_signal(code, relay_code, source)
 
 /obj/item/nanite_remote/ui_state(mob/user)
 	return GLOB.hands_state
@@ -198,9 +205,8 @@
 	SEND_SIGNAL(M, COMSIG_NANITE_COMM_SIGNAL, code, comm_message)
 
 /obj/item/nanite_remote/comm/signal_relay(code, relay_code, source)
-	for(var/X in SSnanites.nanite_relays)
-		var/datum/nanite_program/relay/N = X
-		N.relay_comm_signal(code, relay_code, comm_message)
+	for(var/datum/nanite_program/relay/relays as anything in SSnanites.nanite_relays)
+		relays.relay_comm_signal(code, relay_code, comm_message)
 
 /obj/item/nanite_remote/comm/ui_data()
 	var/list/data = list()

--- a/voidcrew/modules/nanites/code/machines/nanite_cloud_control.dm
+++ b/voidcrew/modules/nanites/code/machines/nanite_cloud_control.dm
@@ -64,8 +64,7 @@
 	disk = null
 
 /obj/machinery/computer/nanite_cloud_controller/proc/get_backup(cloud_id)
-	for(var/I in cloud_backups)
-		var/datum/nanite_cloud_backup/backup = I
+	for(var/datum/nanite_cloud_backup/backup as anything in cloud_backups)
 		if(backup.cloud_id == cloud_id)
 			return backup
 
@@ -178,8 +177,7 @@
 			data["cloud_programs"] = cloud_programs
 	else
 		var/list/backup_list = list()
-		for(var/X in cloud_backups)
-			var/datum/nanite_cloud_backup/backup = X
+		for(var/datum/nanite_cloud_backup/backup as anything in cloud_backups)
 			var/list/cloud_backup = list()
 			cloud_backup["cloud_id"] = backup.cloud_id
 			backup_list += list(cloud_backup)

--- a/voidcrew/modules/nanites/code/nanites_subsystem.dm
+++ b/voidcrew/modules/nanites/code/nanites_subsystem.dm
@@ -25,7 +25,7 @@ PROCESSING_SUBSYSTEM_DEF(nanites)
  * forced - Whether we should check for hardware or not.
  */
 /datum/controller/subsystem/processing/nanites/proc/get_cloud_backup(cloud_id, force = FALSE)
-	for(var/datum/nanite_cloud_backup/backup/backup as anything in cloud_backups)
+	for(var/datum/nanite_cloud_backup/backup as anything in cloud_backups)
 		if(!force && !check_hardware(backup))
 			return
 		if(backup.cloud_id == cloud_id)

--- a/voidcrew/modules/nanites/code/nanites_subsystem.dm
+++ b/voidcrew/modules/nanites/code/nanites_subsystem.dm
@@ -3,19 +3,29 @@ PROCESSING_SUBSYSTEM_DEF(nanites)
 	flags = SS_BACKGROUND|SS_POST_FIRE_TIMING|SS_NO_INIT
 	wait = 10
 
-	var/list/datum/nanite_cloud_backup/cloud_backups = list()
+	///List of all mobs that have nanites, used by Nanite HUD
 	var/list/mob/living/nanite_monitored_mobs = list()
+
+	var/list/datum/nanite_cloud_backup/cloud_backups = list()
 	var/list/datum/nanite_program/relay/nanite_relays = list()
-	var/neural_network_count = 0
 
 /datum/controller/subsystem/processing/nanites/proc/check_hardware(datum/nanite_cloud_backup/backup)
 	if(QDELETED(backup.storage) || (backup.storage.machine_stat & (NOPOWER|BROKEN)))
 		return FALSE
 	return TRUE
 
+/**
+ * ##get_cloud_backup
+ *
+ * Goes through all nanite cloud backups and checks:
+ * 1- It works properly (or is forced)
+ * 2- It is the same ID as the one we are looking for.
+ * Args:
+ * cloud_id - the cloud ID we are looking for
+ * forced - Whether we should check for hardware or not.
+ */
 /datum/controller/subsystem/processing/nanites/proc/get_cloud_backup(cloud_id, force = FALSE)
-	for(var/I in cloud_backups)
-		var/datum/nanite_cloud_backup/backup = I
+	for(var/datum/nanite_cloud_backup/backup/backup as anything in cloud_backups)
 		if(!force && !check_hardware(backup))
 			return
 		if(backup.cloud_id == cloud_id)

--- a/voidcrew/modules/nanites/code/programs/_programs.dm
+++ b/voidcrew/modules/nanites/code/programs/_programs.dm
@@ -3,36 +3,42 @@
 	var/desc = "Warn a coder if you can read this."
 
 	var/datum/component/nanites/nanites
+	///The living host mob of our nanite program.
 	var/mob/living/host_mob
 
-	var/use_rate = 0 			//Amount of nanites used while active
-	var/unique = TRUE			//If there can be more than one copy in the same nanites
-	var/can_trigger = FALSE		//If the nanites have a trigger function (used for the programming UI)
-	var/trigger_cost = 0		//Amount of nanites required to trigger
-	var/trigger_cooldown = 50	//Deciseconds required between each trigger activation
-	var/next_trigger = 0		//World time required for the next trigger activation
+	///Amount of nanites used while active
+	var/use_rate = 0
+	///If there can be more than one copy in the same nanites
+	var/unique = TRUE
+	///If the nanites have a trigger function (used for the programming UI)
+	var/can_trigger = FALSE
+	///Amount of nanites required to trigger
+	var/trigger_cost = 0
+	///Deciseconds required between each trigger activation
+	var/trigger_cooldown = 50
+	///World time required for the next trigger activation
+	var/next_trigger = 0
 
+	///Specific program flags. Options: (NANITE_SHOCK_IMMUNE | NANITE_EMP_IMMUNE)
 	var/program_flags = NONE
-	var/passive_enabled = FALSE //If the nanites have an on/off-style effect, it's tracked by this var
+	///If the nanites have an on/off-style effect, it's tracked by this var
+	var/passive_enabled = FALSE
 
-	var/list/rogue_types = list(/datum/nanite_program/glitch) //What this can turn into if it glitches.
-	//As a rule of thumb, these should be:
-	//A: simpler
-	//B: negative
-	//C: affecting the same parts of the body, roughly
-	//B is mostly a consequence of A: it's always going to be simpler to cause damage than to repair it, so a software bug will not randomly make the flesh eating
-	//nanites learn how to repair cells.
-	//Given enough glitch-swapping you'll end up with stuff like necrotic or toxic nanites, which are very simple as they just try to eat what's in front of them
-	//or just lie around polluting the blood
-
+	///What this can turn into if it glitches.
+	var/list/rogue_types = list(/datum/nanite_program/glitch)
 
 	//The following vars are customizable
-	var/activated = TRUE 			//If FALSE, the program won't process, disables passive effects, can't trigger and doesn't consume nanites
+	///If FALSE, the program won't process, disables passive effects, can't trigger and doesn't consume nanites
+	var/activated = TRUE
 
-	var/timer_restart = 0 			//When deactivated, the program will wait X deciseconds before self-reactivating. Also works if the program begins deactivated.
-	var/timer_shutdown = 0 			//When activated, the program will wait X deciseconds before self-deactivating. Also works if the program begins activated.
-	var/timer_trigger = 0			//[Trigger only] While active, the program will attempt to trigger once every x deciseconds.
-	var/timer_trigger_delay = 0				//[Trigger only] While active, the program will delay trigger signals by X deciseconds.
+	///When deactivated, the program will wait X deciseconds before self-reactivating. Also works if the program begins deactivated.
+	var/timer_restart = 0
+	///When activated, the program will wait X deciseconds before self-deactivating. Also works if the program begins activated.
+	var/timer_shutdown = 0
+	///[Trigger only] While active, the program will attempt to trigger once every x deciseconds.
+	var/timer_trigger = 0
+	///[Trigger only] While active, the program will delay trigger signals by X deciseconds.
+	var/timer_trigger_delay = 0
 
 	//Indicates the next world.time tick where these timers will act
 	var/timer_restart_next = 0
@@ -41,19 +47,24 @@
 	var/timer_trigger_delay_next = 0
 
 	//Signal codes, these handle remote input to the nanites. If set to 0 they'll ignore signals.
-	var/activation_code 	= 0 	//Code that activates the program [1-9999]
-	var/deactivation_code 	= 0 	//Code that deactivates the program [1-9999]
-	var/kill_code 			= 0		//Code that permanently removes the program [1-9999]
-	var/trigger_code 		= 0 	//Code that triggers the program (if available) [1-9999]
+	///Code that activates the program [1-9999]
+	var/activation_code = 0
+	///Code that deactivates the program [1-9999]
+	var/deactivation_code = 0
+	///Code that permanently removes the program [1-9999]
+	var/kill_code = 0
+	///Code that triggers the program (if available) [1-9999]
+	var/trigger_code = 0
 
 	//Extra settings
 	///Don't ever override this or I will come to your house and stand menacingly behind a bush
 	VAR_FINAL/list/extra_settings = list()
 
 	//Rules
-	//Rules that automatically manage if the program's active without requiring separate sensor programs
+	///Whether all rules are required for positive condition or any of specified
+	var/all_rules_required = TRUE
+	///Rules that automatically manage if the program's active without requiring separate sensor programs
 	var/list/datum/nanite_rule/rules = list()
-	var/all_rules_required = TRUE			//Whether all rules are required for positive condition or any of specified
 
 /datum/nanite_program/New()
 	. = ..()
@@ -90,12 +101,11 @@
 	target.trigger_code = trigger_code
 
 	target.rules = list()
-	for(var/R in rules)
-		var/datum/nanite_rule/rule = R
+	for(var/datum/nanite_rule/rule as anything in rules)
 		rule.copy_to(target)
 	target.all_rules_required = all_rules_required
 
-	if(istype(target,src))
+	if(istype(target, src))
 		copy_extra_settings_to(target)
 
 ///Register extra settings by overriding this.
@@ -129,8 +139,8 @@
 		copy_list[ns_name] = extra_setting.get_copy()
 	target.extra_settings = copy_list
 
-/datum/nanite_program/proc/on_add(datum/component/nanites/_nanites)
-	nanites = _nanites
+/datum/nanite_program/proc/on_add(datum/component/nanites/nanites)
+	src.nanites = nanites
 	if(nanites.host_mob)
 		on_mob_add()
 
@@ -279,8 +289,7 @@
 			if(can_trigger)
 				trigger()
 		if(5) //Program is scrambled and does something different
-			var/rogue_type = pick(rogue_types)
-			var/datum/nanite_program/rogue = new rogue_type
+			var/datum/nanite_program/rogue = new pick(rogue_types)
 			nanites.add_program(null, rogue, src)
 			qdel(src)
 
@@ -305,13 +314,13 @@
 
 /datum/nanite_program/protocol/check_conditions()
 	. = ..()
-	for(var/protocol in nanites.protocols)
-		var/datum/nanite_program/protocol/P = protocol
-		if(P != src && P.activated && P.protocol_class == protocol_class)
+	for(var/datum/nanite_program/protocol/protocol as anything in nanites.protocols)
+		if(protocol != src && protocol.activated && protocol.protocol_class == protocol_class)
 			return FALSE
+	return TRUE
 
-/datum/nanite_program/protocol/on_add(datum/component/nanites/_nanites)
-	..()
+/datum/nanite_program/protocol/on_add(datum/component/nanites/nanites)
+	. = ..()
 	nanites.protocols += src
 
 /datum/nanite_program/protocol/Destroy()

--- a/voidcrew/modules/nanites/code/programs/_programs.dm
+++ b/voidcrew/modules/nanites/code/programs/_programs.dm
@@ -289,7 +289,8 @@
 			if(can_trigger)
 				trigger()
 		if(5) //Program is scrambled and does something different
-			var/datum/nanite_program/rogue = new pick(rogue_types)
+			var/rogue_type = pick(rogue_types)
+			var/datum/nanite_program/rogue = new rogue_type
 			nanites.add_program(null, rogue, src)
 			qdel(src)
 

--- a/voidcrew/modules/nanites/code/programs/sensor.dm
+++ b/voidcrew/modules/nanites/code/programs/sensor.dm
@@ -58,10 +58,9 @@
 /datum/nanite_program/sensor/relay_repeat/send_code()
 	var/datum/nanite_extra_setting/relay = extra_settings[NES_RELAY_CHANNEL]
 	if(activated && relay.get_value())
-		for(var/X in SSnanites.nanite_relays)
-			var/datum/nanite_program/relay/N = X
+		for(var/datum/nanite_program/relay/relays as anything in SSnanites.nanite_relays)
 			var/datum/nanite_extra_setting/code = extra_settings[NES_SENT_CODE]
-			N.relay_signal(code.get_value(), relay.get_value(), "a [name] program")
+			relays.relay_signal(code.get_value(), relay.get_value(), "a [name] program")
 
 /datum/nanite_program/sensor/health
 	name = "Health Sensor"

--- a/voidcrew/modules/nanites/code/programs/utility.dm
+++ b/voidcrew/modules/nanites/code/programs/utility.dm
@@ -173,24 +173,24 @@
 	if(!iscarbon(host_mob))
 		return
 	if(host_mob.client)
-		SSnanites.neural_network_count++
+		nanites.linked_techweb.neural_network_count++
 	else
-		SSnanites.neural_network_count += 0.25
+		nanites.linked_techweb.neural_network_count += 0.25
 
 /datum/nanite_program/researchplus/disable_passive_effect()
 	. = ..()
 	if(!iscarbon(host_mob))
 		return
 	if(host_mob.client)
-		SSnanites.neural_network_count--
+		nanites.linked_techweb.neural_network_count--
 	else
-		SSnanites.neural_network_count -= 0.25
+		nanites.linked_techweb.neural_network_count -= 0.25
 
 /datum/nanite_program/researchplus/active_effect()
 	if(!iscarbon(host_mob))
 		return
 	var/mob/living/carbon/C = host_mob
-	var/points = round(SSnanites.neural_network_count / 12, 0.1)
+	var/points = round(nanites.linked_techweb.neural_network_count / 12, 0.1)
 	if(!C.client) //less brainpower
 		points *= 0.25
 	nanites.linked_techweb.add_point_list(list(TECHWEB_POINT_TYPE_GENERIC = points))

--- a/voidcrew/modules/research/edits/_techweb.dm
+++ b/voidcrew/modules/research/edits/_techweb.dm
@@ -1,3 +1,5 @@
 /datum/techweb
+	///Amount of people connected to the Techweb's neural network, which it uses to generate points better.
+	var/neural_network_count = 0
 	///List of everything connected to this techweb via Multitool, used for R&D server deconstruction.
 	var/list/connected_machines = list()


### PR DESCRIPTION
## About The Pull Request

Techwebs now store the players connected to its neural network, rather than SSnanites. I also attempted some code improvement as well, since I had nothing better to do and it will help in the future when trying to improve nanites in general.

I also turned nanite flags into actual flags, and changed the remote's access from Robotics to Research, because it's a Science thing not a Silicon one.

## Why It's Good For The Game

This helps us move away from the subsystem (which is good, why is Nanites even it's own subsystem when it's supposed to be tied into research, why do nanites have a direct reference to a nanite component, what the hell).
