### PR TITLE
Makes the overmap area fullbright

### DIFF
--- a/voidcrew/modules/overmap/code/game/area/areas/overmap.dm
+++ b/voidcrew/modules/overmap/code/game/area/areas/overmap.dm
@@ -7,3 +7,5 @@
 	requires_power = FALSE
 	area_flags = NOTELEPORT
 	flags_1 = NONE
+	static_lighting = FALSE
+	base_lighting_alpha = 255


### PR DESCRIPTION
Yea so like basically, this area was completely dark, I can't remember if it was always like this, or if a CI fix made it this way. But, regardless, you can now actually see the overmap when you're looking at it.